### PR TITLE
fix: Ensure we use g++ v10 so that we can c++20

### DIFF
--- a/ubuntu-20.04.Dockerfile
+++ b/ubuntu-20.04.Dockerfile
@@ -29,6 +29,8 @@ apt-get install -y --no-install-recommends \
   libclang-dev \
   libtool 
 
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+
 # install yarn
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
We need to use c++20 with the version of v8 that ships in Node v24. 

Turns out you need to set the compiler otherwise node-gyp will use the default 🤷‍♂️